### PR TITLE
fix d.ts for WebStorm, IntelliJ IDEA, VS Code

### DIFF
--- a/dio.d.ts
+++ b/dio.d.ts
@@ -383,4 +383,4 @@ declare namespace dio {
 	): Router;
 }
 
-declare module 'dio.js' { export = dio; }
+export = dio;


### PR DESCRIPTION
Not work, when declare module in d.ts. Use simple export.