### PR TITLE
Improved Typescript Definitions

### DIFF
--- a/types/typescript.d.ts
+++ b/types/typescript.d.ts
@@ -360,7 +360,7 @@ declare global {
 
 	namespace JSX {
 		interface Element extends ElementNode {}
-		interface ElementClass extends AbstractComponent<P, S> {}
+		interface ElementClass<P, S> extends AbstractComponent<P, S> {}
 		interface ElementAttributesProperty {props: any}
 		interface ElementChildrenAttribute {children: any}
 		interface IntrinsicAttributes extends Props {}

--- a/types/typescript.d.ts
+++ b/types/typescript.d.ts
@@ -359,7 +359,7 @@ declare global {
 
 	namespace JSX {
 		interface Element extends ElementNode {}
-		interface ElementClass extends AbstractComponent<P, S> {}
+		interface ElementClass extends AbstractComponent<any, any> {}
 		interface ElementAttributesProperty {props: any}
 		interface ElementChildrenAttribute {children: any}
 		interface IntrinsicAttributes extends Props {}

--- a/types/typescript.d.ts
+++ b/types/typescript.d.ts
@@ -213,7 +213,6 @@ interface Events {
 }
 
 interface Props extends Events {
-	[props: string]: any
 	children?: any
 	ref?: Ref
 	key?: Key
@@ -360,7 +359,7 @@ declare global {
 
 	namespace JSX {
 		interface Element extends ElementNode {}
-		interface ElementClass extends AbstractComponent<{}, {}> {}
+		interface ElementClass extends AbstractComponent<P, S> {}
 		interface ElementAttributesProperty {props: any}
 		interface ElementChildrenAttribute {children: any}
 		interface IntrinsicAttributes extends Props {}

--- a/types/typescript.d.ts
+++ b/types/typescript.d.ts
@@ -360,7 +360,7 @@ declare global {
 
 	namespace JSX {
 		interface Element extends ElementNode {}
-		interface ElementClass<P, S> extends AbstractComponent<P, S> {}
+		interface ElementClass extends AbstractComponent<{}, {}> {}
 		interface ElementAttributesProperty {props: any}
 		interface ElementChildrenAttribute {children: any}
 		interface IntrinsicAttributes extends Props {}

--- a/types/typescript.d.ts
+++ b/types/typescript.d.ts
@@ -354,8 +354,8 @@ declare global {
 		export const renderToString: renderToString
 		export const renderToNodeStream: renderToNodeStream
 
-		export abstract class Component<P, S> extends AbstractComponent<P, S> {}
-		export abstract class PureComponent<P, S> extends AbstractComponent<P, S> {}
+		export abstract class Component<P = {}, S = {}> extends AbstractComponent<P, S> {}
+		export abstract class PureComponent<P = {}, S = {}> extends AbstractComponent<P, S> {}
 	}
 
 	namespace JSX {


### PR DESCRIPTION
### Changes

1. The `ElementClass` edit fixes #45 
2. Defaults P, S to `{}` to allow their omission

Use cases:
- Components that don't have props can be extend `Component` instead of extending `Component<{}, {}>
- Codebases that leverage Redux heavily rarely use State. This PR allow to omit specifying a blank state of `{}` every time